### PR TITLE
add salt, and hashed pwd to server schema

### DIFF
--- a/server/domainModels/serverSchemas/User.js
+++ b/server/domainModels/serverSchemas/User.js
@@ -11,4 +11,15 @@ userSchema.methods = {
     }
 };
 
+//adding security fields here
+userSchema.salt = {
+    type:String, 
+    required:"{PATH} is required!"
+}
+
+userSchema.hashed_pwd = {
+    type:String, 
+    required:"{PATH} is required!"
+}
+
 module.exports = userSchema;


### PR DESCRIPTION
this is the backend modification for the add user story. This modifies the server schemas for a user so secure fields do not show up on the add user form. I also added a development branch for the api.